### PR TITLE
[cryptsetup] Update to 2.7.5. JB#62787

### DIFF
--- a/rpm/cryptsetup.spec
+++ b/rpm/cryptsetup.spec
@@ -1,6 +1,6 @@
 Name:    cryptsetup
 Summary: A utility for setting up encrypted disks
-Version: 2.4.3
+Version: 2.7.5
 Release: 1
 License: GPLv2+ and LGPLv2+
 URL: https://gitlab.com/cryptsetup/cryptsetup
@@ -20,6 +20,8 @@ BuildRequires: libtool
 # BuildRequires: libpwquality-devel
 # Requires: libpwquality >= 1.2.0
 
+Obsoletes: %{name}-reencrypt <= %{version}
+Provides: %{name}-reencrypt = %{version}
 Provides: cryptsetup-luks = %{version}-%{release}
 Obsoletes: cryptsetup-luks < 1.4.0
 Requires: cryptsetup-libs = %{version}-%{release}
@@ -64,20 +66,11 @@ Requires: cryptsetup-libs = %{version}-%{release}
 The integritysetup package contains a utility for setting up
 disk integrity protection using dm-integrity kernel module.
 
-%package reencrypt
-Summary: A utility for offline reencryption of LUKS encrypted disks.
-Requires: cryptsetup-libs = %{version}-%{release}
-
-%description reencrypt
-This package contains cryptsetup-reencrypt utility which
-can be used for offline reencryption of disk in situ.
-
 %prep
 %autosetup -n %{name}-%{version}/%{name}
-chmod -x misc/dracut_90reencrypt/*
 
 %build
-%reconfigure --enable-cryptsetup-reencrypt --with-crypto_backend=openssl --disable-ssh-token
+%reconfigure --with-crypto_backend=openssl --disable-ssh-token --disable-asciidoc
 %make_build
 
 %install
@@ -93,40 +86,25 @@ install -D -m 644 scripts/cryptsetup.conf %{buildroot}/%{_tmpfilesdir}
 %postun -n cryptsetup-libs -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license COPYING
-%doc AUTHORS FAQ docs/*ReleaseNotes
-%{_mandir}/man8/cryptsetup.8.gz
+%doc AUTHORS FAQ.md docs/*ReleaseNotes
 %{_sbindir}/cryptsetup
 
 %files -n veritysetup
-%defattr(-,root,root,-)
 %license COPYING
-%{_mandir}/man8/veritysetup.8.gz
 %{_sbindir}/veritysetup
 
 %files -n integritysetup
-%defattr(-,root,root,-)
 %license COPYING
-%{_mandir}/man8/integritysetup.8.gz
 %{_sbindir}/integritysetup
 
-%files reencrypt
-%defattr(-,root,root,-)
-%license COPYING
-%doc misc/dracut_90reencrypt
-%{_mandir}/man8/cryptsetup-reencrypt.8.gz
-%{_sbindir}/cryptsetup-reencrypt
-
 %files devel
-%defattr(-,root,root,-)
 %doc docs/examples/*
 %{_includedir}/libcryptsetup.h
 %{_libdir}/libcryptsetup.so
 %{_libdir}/pkgconfig/libcryptsetup.pc
 
 %files libs -f cryptsetup.lang
-%defattr(-,root,root,-)
 %license COPYING COPYING.LGPL
 %{_libdir}/libcryptsetup.so.*
 %{_tmpfilesdir}/cryptsetup.conf


### PR DESCRIPTION
- reencrypt option removed from upstream -> subpackage dropped
- man pages require now asciidoc -> man pages dropped